### PR TITLE
Address unhandled exception in Safari private mode

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -60,6 +60,14 @@ module.exports = function(config) {
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     browsers: ['Chrome'],
 
+    // create a custom Chrome launcher without the support for localStorage
+    customLaunchers: {
+      Chrome_without_ls: {
+        base: 'Chrome',
+        flags: ['--disable-local-storage']
+      }
+    },
+
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits


### PR DESCRIPTION
This fixes #3. Currently missing tests mainly due to the fact I have no idea (and could not find docco) on how to setup karma environment such that localStorage is missing and/or throws exceptions.

- [ ] Write a test case to cater for missing localStorage
- [ ] Write a test case to cater for localStorage throwing exceptions

Any ideas?