### PR TITLE
Manual saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ React-LocalStorage
 ==================
 
 Simply synchronize a component's state with `localStorage`, when available. Synchronisation happens on unmount or page leave.
+
 Keep in mind that on iOS there is no page leave event. You have to save manually setStateWithLocalStorage/saveStateToLocalStorage if you absolutely
 need the state always synchronized. Same for browser crashes/etc.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 React-LocalStorage
 ==================
 
-Simply synchronize a component's state with `localStorage`, when available.
+Simply synchronize a component's state with `localStorage`, when available. Synchronisation happens on unmount or page leave.
+Keep in mind that on iOS there is no page leave event. You have to save manually setStateWithLocalStorage/saveStateToLocalStorage if you absolutely
+need the state always synchronized. Same for browser crashes/etc.
 
 Usage
 -----
@@ -29,6 +31,12 @@ class TestComponent extends React.Component {
   }
 }
 ```
+
+Api
+-------
+The mixin provides two methods:
+- saveStateToLocalStorage to save the current component state to the local storage
+- setStateWithLocalStorage, which acts like setState but afterwards saves the state to the local storage
 
 Options
 -------

--- a/react-localstorage.js
+++ b/react-localstorage.js
@@ -37,6 +37,24 @@ module.exports = {
     }
   },
 
+
+  /**
+   * Save current state to local storage
+   */
+  saveStateToLocalStorage: function() {
+    saveStateToLocalStorage(this)
+  },
+
+  /**
+   * Set state and when done save to local storage
+   */
+  setStateWithLocalStorage: function(state, callback) {
+    this.setState(state, function() {
+      saveStateToLocalStorage(this)
+      callback && callback()
+    })
+  },
+
   /**
    * Load data.
    * This seems odd to do this on componentDidMount, but it prevents server checksum errors.


### PR DESCRIPTION
On iOS there is no page leave event. If the browser crashes there is none too. Meaning no unmount happens. To save reliable one needs to be able to save the state to local storage manually. 

Added two new APIs:

- saveStateToLocalStorage to save the current component state to the local storage
- setStateWithLocalStorage, which acts like setState but afterwards saves the state to the local storage