### PR TITLE
Export higher-ordered component instead of mixin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,8 @@
 {
   root: true,
+  parserOptions: {
+    ecmaVersion: 6,
+  },
   extends: [
     "eslint:recommended",
   ],

--- a/README.md
+++ b/README.md
@@ -10,11 +10,9 @@ A simple component:
 
 ```javascript
 const React = require('react');
-const LocalStorageMixin = require('react-localstorage');
-const reactMixin = require('react-mixin');
+const withLocalStorage = require('react-localstorage');
 
 // This is all you need to do
-@reactMixin.decorate(LocalStorageMixin)
 class TestComponent extends React.Component {
   static displayName = 'TestComponent';
 
@@ -28,6 +26,8 @@ class TestComponent extends React.Component {
     return <span onClick={this.onClick}>{this.state.counter}</span>;
   }
 }
+
+export default withLocalStorage(TestComponent)
 ```
 
 Options
@@ -75,7 +75,7 @@ getStateFilterKeys: function() {
 Server Rendering
 ----------------
 
-`LocalStorageMixin` will call `setState` on `componentDidMount`, so it will not break server rendering
+`withLocalStorage` will call `setState` on `componentDidMount`, so it will not break server rendering
 checksums. This is new as of `0.2.0`.
 
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ class TestComponent extends React.Component {
 export default withLocalStorage(TestComponent)
 ```
 
+If you need to save the state manually, call the component's `saveStateToLocalStorage()` method.
+See https://github.com/STRML/react-localstorage/pull/17 for context.
+
 Options
 -------
 

--- a/package.json
+++ b/package.json
@@ -40,5 +40,7 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },
-  "dependencies": {}
+  "dependencies": {
+    "synchronous-promise": "^2.0.5"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-localstorage",
   "version": "1.0.0",
-  "description": "A mixin for automatically synchronizing a component's state with localStorage.",
+  "description": "A higher-ordered component for automatically synchronizing a component's state with localStorage.",
   "main": "react-localstorage.js",
   "scripts": {
     "test": "jest",
@@ -35,7 +35,6 @@
     "precommit": "^1.2.2",
     "react": "^16",
     "react-dom": "^16",
-    "react-mixin": "^4.0.0",
     "regenerator-runtime": "^0.11.1"
   },
   "publishConfig": {

--- a/react-localstorage.js
+++ b/react-localstorage.js
@@ -35,12 +35,16 @@ module.exports = Component => {
      * If the page unloads, this may not fire, so we also mount the function to onbeforeunload.
      */
     componentWillUnmount() {
-      saveStateToLocalStorage(this);
+      this.saveStateToLocalStorage();
 
       // Remove beforeunload handler if it exists.
       if (this.__react_localstorage_beforeunload) {
         global.removeEventListener('beforeunload', this.__react_localstorage_beforeunload);
       }
+    }
+
+    saveStateToLocalStorage () {
+      saveStateToLocalStorage(this)
     }
 
     /**

--- a/react-localstorage.js
+++ b/react-localstorage.js
@@ -35,6 +35,10 @@ module.exports = Component => {
      * If the page unloads, this may not fire, so we also mount the function to onbeforeunload.
      */
     componentWillUnmount() {
+      if (super.componentWillUnmount) {
+        super.componentWillUnmount()
+      }
+
       this.saveStateToLocalStorage();
 
       // Remove beforeunload handler if it exists.
@@ -64,6 +68,9 @@ module.exports = Component => {
         global.addEventListener('beforeunload', this.__react_localstorage_beforeunload);
       }
 
+      if (super.componentDidMount) {
+        super.componentDidMount()
+      }
     }
   }
 

--- a/test/react-localstorage.test.js
+++ b/test/react-localstorage.test.js
@@ -190,6 +190,12 @@ describe("suite", function() {
     );
   });
 
+  it("should load state before calling componentDidMount() of wrapped component", async function() {
+    ls.setItem(ComponentUseDisplayName.displayName, JSON.stringify({c: 'baz'}));
+    const component = TestUtil.renderIntoDocument(<ComponentUseDisplayName />);
+    assert.deepEqual(component.state, {c: 'baz'})
+  });
+
   it("should shut off LS syncing with localStorageKey=false", function() {
     const component = TestUtil.renderIntoDocument(<ComponentUseDisplayName />);
     component.setState({

--- a/test/react-localstorage.test.js
+++ b/test/react-localstorage.test.js
@@ -1,8 +1,7 @@
 const React = require('react');
 const TestUtil = require('react-dom/test-utils');
-const LocalStorageMixin = require('../react-localstorage');
+const withLocalStorage = require('../react-localstorage');
 const assert = require('assert');
-const reactMixin = require('react-mixin');
 
 const ls = global.localStorage;
 describe("suite", function() {
@@ -12,13 +11,13 @@ describe("suite", function() {
     console.warn = function() { throw new Error([].slice.call(arguments).join(' ')); };
   });
 
-  @reactMixin.decorate(LocalStorageMixin)
-  class ComponentUseDisplayName extends React.Component {
+  class _ComponentUseDisplayName extends React.Component {
     static displayName = 'component1';
     render() {
       return <div>hello</div>;
     }
   }
+  const ComponentUseDisplayName = withLocalStorage(_ComponentUseDisplayName)
 
   // Change in v1; we now do this on componentWillUnmount
   it("should not save after each setState", function(done) {
@@ -47,8 +46,7 @@ describe("suite", function() {
     );
   });
 
-  @reactMixin.decorate(LocalStorageMixin)
-  class ComponentUseStorageKey extends React.Component {
+  class _ComponentUseStorageKey extends React.Component {
     static displayName = 'component2';
     static defaultProps = {
       'localStorageKey': 'component-key'
@@ -57,6 +55,7 @@ describe("suite", function() {
       return <div>hello</div>;
     }
   }
+  const ComponentUseStorageKey = withLocalStorage(_ComponentUseStorageKey)
 
   it("should use this.props.localStorageKey to store into localstorage", function() {
     const component = TestUtil.renderIntoDocument(<ComponentUseStorageKey />);
@@ -70,8 +69,7 @@ describe("suite", function() {
     );
   });
 
-  @reactMixin.decorate(LocalStorageMixin)
-  class ComponentUseMethod extends React.Component {
+  class _ComponentUseMethod extends React.Component {
     static displayName = 'ComponentUseMethod';
     getLocalStorageKey() {
       return this.constructor.displayName + 'DynamicSuffix';
@@ -80,6 +78,7 @@ describe("suite", function() {
       return <div>hello</div>;
     }
   }
+  const ComponentUseMethod = withLocalStorage(_ComponentUseMethod)
 
   it("should use this.getLocalStorageKey() to store into localstorage", function() {
     const component = TestUtil.renderIntoDocument(<ComponentUseMethod />);
@@ -93,13 +92,13 @@ describe("suite", function() {
     );
   });
 
-  @reactMixin.decorate(LocalStorageMixin)
-  class ComponentWithNoSetting extends React.Component {
+  class _ComponentWithNoSetting extends React.Component {
     static displayName = 'ComponentWithNoSetting';
     render() {
       return <div>hello</div>;
     }
   }
+  const ComponentWithNoSetting = withLocalStorage(_ComponentWithNoSetting)
 
   it("should use ComponentWithNoSetting to store into localstorage", function() {
     const component = TestUtil.renderIntoDocument(<ComponentWithNoSetting />);
@@ -113,8 +112,7 @@ describe("suite", function() {
     );
   });
 
-  @reactMixin.decorate(LocalStorageMixin)
-  class ComponentUseStateFilter extends React.Component {
+  class _ComponentUseStateFilter extends React.Component {
     static displayName = 'componentStateFilter';
     static defaultProps = {
       stateFilterKeys: ['a', 'b']
@@ -123,6 +121,7 @@ describe("suite", function() {
       return <div>hello</div>;
     }
   }
+  const ComponentUseStateFilter = withLocalStorage(_ComponentUseStateFilter)
 
   it("should only use state keys that match filter", function() {
     const component = TestUtil.renderIntoDocument(<ComponentUseStateFilter />);
@@ -138,8 +137,7 @@ describe("suite", function() {
     );
   });
 
-  @reactMixin.decorate(LocalStorageMixin)
-  class ComponentUseStateFilterFunc extends React.Component {
+  class _ComponentUseStateFilterFunc extends React.Component {
     static displayName = 'componentStateFilterFunc';
     getStateFilterKeys() {
       return ['a', 'b'];
@@ -148,6 +146,7 @@ describe("suite", function() {
       return <div>hello</div>;
     }
   }
+  const ComponentUseStateFilterFunc = withLocalStorage(_ComponentUseStateFilterFunc)
 
   it("should only use state keys that match filter function", function() {
     const component = TestUtil.renderIntoDocument(<ComponentUseStateFilterFunc />);

--- a/test/react-localstorage.test.js
+++ b/test/react-localstorage.test.js
@@ -162,6 +162,34 @@ describe("suite", function() {
     );
   });
 
+  class _ComponentWithLifecycle extends React.Component {
+    static displayName = 'ComponentWithLifecycle';
+    componentDidMount() {
+      this.setState({
+        a: 'world',
+      });
+    }
+    render() {
+      return <div>hello</div>;
+    }
+    componentWillUnmount() {
+      this.setState({
+        b: 'bar',
+      });
+    }
+  }
+  const ComponentWithLifecycle = withLocalStorage(_ComponentWithLifecycle)
+
+  it("should run lifecycle methods of wrapped component", async function() {
+    const component = TestUtil.renderIntoDocument(<ComponentWithLifecycle />);
+    assert.deepEqual(component.state, {a: 'world'})
+    component.componentWillUnmount();
+    assert.equal(
+      JSON.stringify({a: 'world', 'b': 'bar'}),
+      ls.getItem('ComponentWithLifecycle')
+    );
+  });
+
   it("should shut off LS syncing with localStorageKey=false", function() {
     const component = TestUtil.renderIntoDocument(<ComponentUseDisplayName />);
     component.setState({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2787,13 +2787,6 @@ react-dom@^16:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-mixin@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/react-mixin/-/react-mixin-4.0.0.tgz#a19701338301c8bd06a864cb52520c7926d77cc9"
-  dependencies:
-    object-assign "^4.0.1"
-    smart-mixin "^2.0.0"
-
 react@^16:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
@@ -3094,10 +3087,6 @@ slice-ansi@1.0.0:
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
   dependencies:
     is-fullwidth-code-point "^2.0.0"
-
-smart-mixin@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/smart-mixin/-/smart-mixin-2.0.0.tgz#a34a1055e32a75b30d2b4e3ca323dc99cb53f437"
 
 sntp@1.x.x:
   version "1.0.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3268,6 +3268,10 @@ symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
+synchronous-promise@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.5.tgz#4e0fc8dd3f0062720dcc4cefbd9eae62b40637d8"
+
 table@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/table/-/table-4.0.2.tgz#a33447375391e766ad34d3486e6e2aedc84d2e36"


### PR DESCRIPTION
This is a breaking change that addresses https://github.com/STRML/react-localstorage/issues/16#issuecomment-328123629 using code adapted from https://github.com/marklundin/react-localstorage-hoc/tree/d49f2aed97f0a8fe8323d7df51047ff1e901aa0d

(it's easier to review ignoring whitespace: https://github.com/STRML/react-localstorage/pull/18/files?w=1)